### PR TITLE
Revert "Update html-proofer requirement from ~> 4.4 to ~> 5.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "jekyll-theme-chirpy", "~> 6.5"
 
 group :test do
-  gem "html-proofer", "~> 5.0"
+  gem "html-proofer", "~> 4.4"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
Reverts northportio/northportio.github.io#1